### PR TITLE
enabling build on centos

### DIFF
--- a/carbon-cache.initd
+++ b/carbon-cache.initd
@@ -1,3 +1,10 @@
+#!/bin/sh
+#
+# graphite-carbon-cache  init file for starting up the carbon-cache daemon
+#
+# chkconfig:   2345 20 80
+# description: Starts and stops the carbon-cache daemon.
+#
 ### BEGIN INIT INFO
 # Provides:          graphite-carbon-cache
 # Required-Start:    $local_fs $remote_fs $network $syslog $named

--- a/carbon-relay.initd
+++ b/carbon-relay.initd
@@ -1,3 +1,10 @@
+#!/bin/sh
+#
+# graphite-carbon-relay  init file for starting up the carbon-relay daemon
+#
+# chkconfig:   2345 20 80
+# description: Starts and stops the carbon-relay daemon.
+#
 ### BEGIN INIT INFO
 # Provides:          graphite-carbon-relay
 # Required-Start:    $local_fs $remote_fs $network $syslog $named

--- a/graphite-dependencies.rb
+++ b/graphite-dependencies.rb
@@ -12,7 +12,14 @@ class GraphiteDependencies < FPM::Cookery::Recipe
 
   section 'interpreters'
   
-  depends 'libcairo2', 'libffi-dev'
+  platforms [:ubuntu, :debian] do
+    depends 'libcairo2', 'libffi-dev'
+  end
+
+  platforms [:fedora, :redhat, :centos] do
+    build_depends 'cairo-devel', 'libffi-devel'
+    depends 'cairo', 'libffi'
+  end
 
   def build
     # Do nothing

--- a/python.rb
+++ b/python.rb
@@ -14,13 +14,24 @@ class Python < FPM::Cookery::Recipe
 
   section 'interpreters'
 
-  build_depends 'mime-support', 'libbz2-dev', 'libdb-dev', 'libexpat-dev', 'libgcc1',
-                'libncurses-dev', 'libreadline6-dev', 'libsqlite3-dev', 'libtinfo-dev',
-                'libssl-dev', 'g++'
+  platforms [:ubuntu, :debian] do
+    build_depends 'mime-support', 'libbz2-dev', 'libdb-dev', 'libexpat-dev', 'libgcc1',
+                  'libncurses-dev', 'libreadline6-dev', 'libsqlite3-dev', 'libtinfo-dev',
+                  'libssl-dev', 'g++'
 
-  depends       'mime-support', 'libbz2-1.0', 'libdb5.1', 'libexpat1', 'libgcc1',
-                'libncurses5', 'libreadline6', 'libsqlite3-0', 'libtinfo5',
-                'libssl1.0.0'
+    depends       'mime-support', 'libbz2-1.0', 'libdb5.1', 'libexpat1', 'libgcc1',
+                  'libncurses5', 'libreadline6', 'libsqlite3-0', 'libtinfo5',
+                  'libssl1.0.0'
+  end
+
+  platforms [:fedora, :redhat, :centos] do
+    build_depends 'bzip2-devel', 'db4-devel', 'expat-devel', 'libgcc',
+                  'ncurses-devel', 'readline-devel', 'sqlite-devel', 
+                  'openssl-devel', 'gcc-c++'
+    depends       'bzip2-libs', 'db4', 'expat', 'libgcc',
+                  'ncurses-libs', 'readline', 'sqlite',
+                  'openssl'
+  end
 
   def build
     configure :prefix => "/opt/graphite-omnibus", 'disable-install-doc' => true, 'enable-unicode' => 'ucs4'


### PR DESCRIPTION
Initial work to get CentOS working. This will cook on CentOS 6 as is.

In CentOS 7 and Fedora 21 the db4 and the -devel packager were renamed to libdb4. I've submitted an issue upstream https://github.com/bernd/fpm-cookery/issues/98 so platform version can be detected.
